### PR TITLE
Refactoring tests + adding one for the css loading

### DIFF
--- a/tests/specs/rajoyirize-spec.js
+++ b/tests/specs/rajoyirize-spec.js
@@ -26,7 +26,47 @@ describe("Initialisation of rajoyirize plugin", function () {
         expect(myRajoy.autostart).toBeFalsy();
     });
 
-    describe("On start plugin", function () {
+    it("should create container element", function () {
+        expect(myRajoy.rajoyirizeContainer).not.toBeNull();
+        expect(myRajoy.rajoyirizeContainer.id).toEqual('rajoyirize-container');
+        expect(myRajoy.rajoyirizeContainer.className).toContain('hidden');
+    });
+
+    it("should create an image element and add it to the container", function () {
+        var rajoyirizeImage = myRajoy.rajoyirizeContainer.getElementsByTagName('img')[0];
+
+        expect(rajoyirizeImage).not.toBeNull();
+        expect(rajoyirizeImage.width).toEqual(250);
+        expect(rajoyirizeImage.height).toEqual(250);
+        expect(rajoyirizeImage.src).toContain('/assets/images/rajoy/rajoy.png');
+    });
+
+    it("should create a text element and add it to the container", function () {
+        var rajoyirizeQuote = myRajoy.rajoyirizeContainer.getElementsByTagName('p')[0];
+
+        expect(rajoyirizeQuote).not.toBeNull();
+    });
+
+    it("should load the style sheet", function () {
+        var links = document.getElementsByTagName('link');
+        var link;
+        var loadedStyleSheet = false;
+
+        for (var i = 0; i < links.lenght; i ++) {
+            link = links[i];
+
+            if (link.type === 'text/css'
+                && link.rel === 'stylesheet'
+                && link.src.indexOf('/assets/styles.css') > -1 ) {
+
+                loadedStyleSheet = link;
+            }
+        }
+
+        expect(loadedStyleSheet).not.toBe(null);
+    });
+
+    describe("Non default plugin options", function () {
         var testContainerId = 'test-container';
         var testImageSrc = 'path/to/the/image';
 
@@ -48,33 +88,30 @@ describe("Initialisation of rajoyirize plugin", function () {
             expect(myRajoy.rajoyImageSrc).toBe(testImageSrc);
         });
 
-        it("should create container element and add it to the html", function () {
-            var rajoyirizeContainer = document.getElementById(testContainerId);
-
-            expect(rajoyirizeContainer).not.toBeNull();
-            expect(rajoyirizeContainer.id).toEqual(testContainerId);
-            expect(rajoyirizeContainer.className).toContain('hidden');
+        it("should use the container ID passed in the options for the container", function () {
+            expect(myRajoy.rajoyirizeContainer.id).toBe(testContainerId);
         });
 
-        it("should create an image element and add it to the container", function () {
-            var rajoyirizeContainer = document.getElementById(testContainerId);
-            var rajoyirizeImage = rajoyirizeContainer.getElementsByTagName('img')[0];
+        it("should use the image source passed in the options", function () {
+            var rajoyirizeImage = myRajoy.rajoyirizeContainer.getElementsByTagName('img')[0];
 
-            expect(rajoyirizeImage).not.toBeNull();
-            expect(rajoyirizeImage.width).toEqual(250);
-            expect(rajoyirizeImage.height).toEqual(250);
             expect(rajoyirizeImage.src).toContain(testImageSrc);
         });
+    });
 
-        it("should create a text element and add it to the container", function () {
-            var rajoyirizeContainer = document.getElementById(testContainerId);
-            var rajoyirizeQuote = rajoyirizeContainer.getElementsByTagName('p')[0];
+    describe("On start plugin", function () {
+        beforeEach(function () {
+            myRajoy = new Rajoyirize({
+                autostart: true
+            });
+        });
 
-            expect(rajoyirizeQuote).not.toBeNull();
+        afterEach(function () {
+            myRajoy = undefined;
         });
 
         it("should load a random quote into the container", function () {
-            expect(document.getElementById(testContainerId).innerHTML).not.toBe('');
+            expect(document.getElementById('rajoyirize-container').innerHTML).not.toBe('');
         });
     });
 });


### PR DESCRIPTION
Refactored tests:
- Moved the ones about creating HTML elements in the _Initialisation_ `describe`, as that is done before `start`is called.
- Added a new one for the non-default options being used

Also added a new test for the loading of the CSS stylesheet.
