### PR TITLE
Fixing Github pages (demo page)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 node_modules
-assets/styles.css

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,11 @@
+#rajoyirize-container { font-family: Arial; font-size: 16px; width: 100%; position: absolute; bottom: 0; left: 0; overflow: hidden; }
+
+#rajoyirize-container.hidden, #rajoyirize-container .hidden { display: none !important; }
+
+#rajoyirize-container .rajoyirize-content-wrapper { position: fixed; width: 100%; transition: 1s all ease-in-out; bottom: 0; right: -100%; opacity: 0; }
+
+#rajoyirize-container .rajoyirize-content-wrapper.active { transition: 1s all ease-in-out; right: 0; opacity: 1; }
+
+#rajoyirize-container .rajoyirize-content-wrapper img { float: left; }
+
+#rajoyirize-container .rajoyirize-content-wrapper p { float: left; width: 100%; margin: 0; bottom: 0; padding: 20px; background: #000; color: #FFF; opacity: 0.8; }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/lochus/rajoyirize",
   "devDependencies": {
     "http-server": "^0.9.0",
-    "node-sass": "^3.4.2"
+    "node-sass": "^3.13.1"
   }
 }

--- a/src/rajoyirize.js
+++ b/src/rajoyirize.js
@@ -30,7 +30,7 @@
             userSettings = userSettings || {};
 
             finalSettings.rajoyirizeContainerID = userSettings.containerId || 'rajoyirize-container';
-            finalSettings.rajoyImageSrc = userSettings.imageSrc || '/assets/images/rajoy/rajoy.png';
+            finalSettings.rajoyImageSrc = userSettings.imageSrc || 'assets/images/rajoy/rajoy.png';
             finalSettings.visibleTime = userSettings.visibleTime || 6000;
             finalSettings.autostart = userSettings.autostart || false;
 

--- a/src/rajoyirize.js
+++ b/src/rajoyirize.js
@@ -17,7 +17,7 @@
         function includeStyles() {
             var link = d.createElement("link");
 
-            link.href = "/assets/styles.css";
+            link.href = "assets/styles.css";
             link.rel = "stylesheet";
             link.type = "text/css";
 


### PR DESCRIPTION
Earlier today I enabled Github pages for the repo, using the demo page<sup>1</sup> for it: http://fromspaintouk.github.io/rajoyirize/

However, it didn't completely work. The problems were:
1. Missing compiled styles, as we only push Sass file
2. Absolute path of the image and styles file

I made both paths relative (although this is still not feasible as final solution) and pushed the CSS generated file so that it can be used. We'd need a way to ensure that it's always synchronized with the Sass version, though...

Also updated the version of `node-sass` because otherwise I wasn't able to use it anymore, due to environment problems ¯\\\_(ツ)_/¯ (hope this doesn't cause problems to you!)

<sub>1. Had to rename it to `index.html` for it to work (if it can't find that file, it automatically uses the Readme).</sub>